### PR TITLE
Week 1-2 bug fixes and validation

### DIFF
--- a/public/api/edit_order.php
+++ b/public/api/edit_order.php
@@ -1,0 +1,87 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['error' => 'Method not allowed']);
+    exit;
+}
+
+if (!isset($_SESSION['UserID'])) {
+    http_response_code(403);
+    echo json_encode(['error' => 'Unauthorized']);
+    exit;
+}
+
+require_once __DIR__ . '/../../src/Database.php';
+$pdo = Database::connect();
+
+$productionNumber = Database::sanitizeString($_POST['ProductionNumber'] ?? '');
+$emptyTube = Database::sanitizeString($_POST['EmptyTubeNumber'] ?? '');
+$projectID = $_POST['ProjectID'] !== '' ? (int)$_POST['ProjectID'] : null;
+$modelID = $_POST['ModelID'] !== '' ? (int)$_POST['ModelID'] : null;
+$status = Database::sanitizeString($_POST['MC02_Status'] ?? '');
+
+if (!$productionNumber) {
+    http_response_code(422);
+    echo json_encode(['error' => 'Invalid production number']);
+    exit;
+}
+
+try {
+    $pdo->beginTransaction();
+
+    $stmt = $pdo->prepare('UPDATE ProductionOrders SET EmptyTubeNumber = ?, ProjectID = ?, ModelID = ?, MC02_Status = ? WHERE ProductionNumber = ?');
+    $stmt->execute([$emptyTube, $projectID, $modelID, $status, $productionNumber]);
+
+    $pdo->prepare('DELETE FROM MC02_LinerUsage WHERE ProductionNumber = ?')->execute([$productionNumber]);
+    if (!empty($_POST['liner'])) {
+        $luStmt = $pdo->prepare('INSERT INTO MC02_LinerUsage (ProductionNumber, LinerType, LinerBatchNumber, Remarks) VALUES (?, ?, ?, ?)');
+        foreach ($_POST['liner'] as $liner) {
+            $linerType = Database::sanitizeString($liner['LinerType'] ?? '');
+            if ($linerType === '') {
+                continue;
+            }
+            $batch = Database::sanitizeString($liner['LinerBatchNumber'] ?? '');
+            $remarks = Database::sanitizeString($liner['Remarks'] ?? '');
+            $luStmt->execute([$productionNumber, $linerType, $batch, $remarks]);
+        }
+    }
+
+    $pdo->prepare('DELETE FROM MC02_ProcessLog WHERE ProductionNumber = ?')->execute([$productionNumber]);
+    if (!empty($_POST['log'])) {
+        $logStmt = $pdo->prepare('INSERT INTO MC02_ProcessLog (ProductionNumber, SequenceNo, ProcessStepName, DatePerformed, Result, Operator_UserID, Remarks, ControlValue, ActualMeasuredValue) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)');
+        foreach ($_POST['log'] as $log) {
+            $step = Database::sanitizeString($log['ProcessStepName'] ?? '');
+            if ($step !== '') {
+                $logStmt->execute([
+                    $productionNumber,
+                    (int)($log['SequenceNo'] ?? 0),
+                    $step,
+                    $log['DatePerformed'] ?: null,
+                    Database::sanitizeString($log['Result'] ?? ''),
+                    $log['Operator_UserID'] !== '' ? (int)$log['Operator_UserID'] : null,
+                    Database::sanitizeString($log['Remarks'] ?? ''),
+                    $log['ControlValue'] !== '' ? $log['ControlValue'] : null,
+                    $log['ActualMeasuredValue'] !== '' ? $log['ActualMeasuredValue'] : null,
+                ]);
+            }
+        }
+    }
+
+    $pdo->commit();
+
+    // Return updated logs for immediate UI update
+    $logs = $pdo->prepare('SELECT * FROM MC02_ProcessLog WHERE ProductionNumber = ? ORDER BY SequenceNo');
+    $logs->execute([$productionNumber]);
+
+    echo json_encode([
+        'success' => true,
+        'logs' => $logs->fetchAll(PDO::FETCH_ASSOC)
+    ]);
+} catch (Exception $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => 'Error updating order']);
+}

--- a/public/assets/css/app.css
+++ b/public/assets/css/app.css
@@ -127,3 +127,16 @@ body { padding-top: 70px; }
 #loading-overlay {
     backdrop-filter: blur(2px);
 }
+
+.loading-spinner {
+    width: 3rem;
+    height: 3rem;
+    border: 0.4em solid rgba(0, 0, 0, 0.1);
+    border-top-color: #007bff;
+    border-radius: 50%;
+    animation: spinner 0.75s linear infinite;
+}
+
+@keyframes spinner {
+    to { transform: rotate(360deg); }
+}

--- a/public/templates/header.php
+++ b/public/templates/header.php
@@ -11,7 +11,7 @@
 </head>
 <body>
 <div id="loading-overlay" class="position-fixed top-0 start-0 w-100 h-100 bg-white bg-opacity-50 d-none align-items-center justify-content-center" style="z-index:1055;">
-    <div class="spinner-border text-primary" role="status"></div>
+    <div class="loading-spinner" role="status"></div>
 </div>
 <div id="toast-container" class="position-fixed top-0 end-0 p-3" style="z-index:1100;"></div>
 <?php include __DIR__ . '/navigation.php'; ?>

--- a/src/Database.php
+++ b/src/Database.php
@@ -4,7 +4,8 @@ class Database
     private static $pdo;
 
     public static function connect()
-    {        if (!self::$pdo) {
+    {
+        if (!self::$pdo) {
             $config = include __DIR__ . '/../config.php';
             $db = $config['db'];
             $dsn = "mysql:host={$db['host']};dbname={$db['database']};charset=utf8mb4";
@@ -12,6 +13,16 @@ class Database
             self::$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         }
         return self::$pdo;
+    }
+
+    /**
+     * Sanitize input string to prevent XSS and trim whitespace.
+     * This should be used for display purposes only. Database
+     * queries rely on prepared statements for security.
+     */
+    public static function sanitizeString($value)
+    {
+        return htmlspecialchars(trim((string) $value), ENT_QUOTES, 'UTF-8');
     }
 }
 ?>


### PR DESCRIPTION
## Summary
- add sanitization helper in `Database`
- update create/edit order scripts for sanitized inputs
- add AJAX API for editing orders
- add loading spinner styles and update header
- implement dynamic AJAX update on edit order page

## Testing
- `php -l public/api/edit_order.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fa2b8614832f9eb59e104f6a508f